### PR TITLE
define MSRV, add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# adapted from https://github.com/taiki-e/cargo-hack/blob/main/.github/workflows/release.yml
+
+name: Publish release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'oxidecomputer'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish -p oxnet
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - uses: taiki-e/create-gh-release-action@72d65cee1f8033ef0c8b5d79eaf0c45c7c578ce3 # v1
+        with:
+          changelog: CHANGELOG.md
+          title: oxnet $version
+          branch: main
+          prefix: oxnet
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        # 1.78 is the MSRV
+        rust-version: [ stable, "1.78" ]
         features: [ all, default ]
         include:
           - features: all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,9 @@ jobs:
             feature_flags: --all-features
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust-version }}
       - name: Report cargo version
         run: cargo --version
       - name: Report rustc version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
-## Unreleased
+## [0.1.0] - 2025-02-10
 
 Initial release.
+
+[0.1.0]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oxnet"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.78.0"
 license = "MIT OR Apache-2.0"
 description = "commonly used networking primitives with common traits implemented"
 readme = "README.md"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,8 @@
+sign-tag = true
+# Required for templates below to work
+consolidate-commits = false
+pre-release-commit-message = "[{{crate_name}}] version {{version}}"
+tag-message = "[{{crate_name}}] version {{version}}"
+tag-name = "oxnet-{{version}}"
+publish = false
+dependent-version = "upgrade"


### PR DESCRIPTION
Define the MSRV to be Rust 1.78 as a version from a few months ago (it is the
first to support the lockfile v4 format that's currently checked in).

With this change, you can now:

* update `CHANGELOG.md`
* install cargo-release if not already done so
* run `cargo release <version> --execute`, e.g. `cargo release 0.1.0 --execute`

and the release happens automatically.
