### PR TITLE
Bump min version for ula fn + mcast admin check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # 1.78 is the MSRV
-        rust-version: [ stable, "1.78" ]
-        features: [ all, default ]
+        # 1.84 is the MSRV
+        rust-version: [stable, "1.84"]
+        features: [all, default]
         include:
           - features: all
             feature_flags: --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2] - 2025-05-25
+
+* Bumps Rust min-version to 1.84 for direct `is_unique_local` call on IPv6
+      addresses.
+* Adds `is_admin_scoped_multicast` check for multicast IPv6 addresses that are
+      site-local or org scoped
+
 ## [0.1.1] - 2025-02-25
 
 * Adds `is_subnet_of`/`is_supernet_of`/`overlaps`, for verifying disjoint
@@ -12,5 +19,6 @@
 
 Initial release.
 
+[0.1.2]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.2
 [0.1.1]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.1
 [0.1.0]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "oxnet"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "expectorate",
  "ipnetwork",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oxnet"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.84.0"
 license = "MIT OR Apache-2.0"
 description = "commonly used networking primitives with common traits implemented"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxnet"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.84.0"
 license = "MIT OR Apache-2.0"

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -138,6 +138,27 @@ impl IpNet {
         }
     }
 
+    /// Return `true` iff this subnet is in a multicast address range with
+    /// administrative scope (site-local or organization-local) as defined in
+    /// [RFC 4291].
+    ///
+    /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
+    pub const fn is_admin_scoped_multicast(&self) -> bool {
+        match self {
+            IpNet::V4(_inner) => false, // IPv4 does not support ULA
+            IpNet::V6(inner) => inner.is_admin_scoped_multicast(),
+        }
+    }
+
+    /// Return `true` iff this subnet is in a Unique Local Address range.
+    /// This is only valid for IPv6 addresses.
+    pub const fn is_unique_local(&self) -> bool {
+        match self {
+            IpNet::V4(_inner) => false, // IPv4 does not support ULA
+            IpNet::V6(inner) => inner.is_unique_local(),
+        }
+    }
+
     /// Return `true` iff this subnet is in a loopback address range.
     pub const fn is_loopback(&self) -> bool {
         match self {
@@ -606,6 +627,24 @@ impl Ipv6Net {
         self.addr.is_multicast()
     }
 
+    /// Return `true` if this address is a multicast address with
+    /// administrative scope (site-local or organization-local) as defined in
+    /// [RFC 4291].
+    ///
+    /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
+    pub const fn is_admin_scoped_multicast(&self) -> bool {
+        if !self.addr.is_multicast() {
+            return false;
+        }
+
+        // Extract the scope field (bits 4-7 of the second byte)
+        let segments = self.addr.segments();
+        let scope = (segments[0] & 0x000F) as u8;
+
+        // RFC 4291: Scope values 5 (site-local) and 8 (organization-local)
+        matches!(scope, 0x5 | 0x8)
+    }
+
     /// Return `true` iff this subnet is in a loopback address range.
     pub const fn is_loopback(&self) -> bool {
         self.addr.is_loopback()
@@ -624,10 +663,11 @@ impl Ipv6Net {
     }
 
     /// Return `true` if this subnetwork is in the IPv6 Unique Local Address
-    /// range defined in RFC 4193, e.g., `fd00:/8`
-    pub fn is_unique_local(&self) -> bool {
-        // TODO: Delegate to `Ipv6Addr::is_unique_local()` when stabilized.
-        self.first_addr().octets()[0] == 0xfd
+    /// range defined in [RFC 4193], e.g., `fd00:/8`.
+    ///
+    /// [RFC 4193]: https://tools.ietf.org/html/rfc4193
+    pub const fn is_unique_local(&self) -> bool {
+        self.addr.is_unique_local()
     }
 
     /// Return the first address within this subnet.
@@ -1075,5 +1115,35 @@ mod tests {
         // this form.
         let unspec: IpNet = "0.0.0.0/0".parse().unwrap();
         assert!(unspec.is_network_address());
+    }
+
+    #[test]
+    fn test_is_multicast_with_scopes() {
+        // IPv4 multicast tests (224.0.0.0/4 is the IPv4 multicast range)
+        let v4_mcast: IpNet = "224.0.0.1/32".parse().unwrap();
+        let v4_not_mcast: IpNet = "192.168.1.1/24".parse().unwrap();
+
+        assert!(v4_mcast.is_multicast());
+        assert!(!v4_not_mcast.is_multicast());
+
+        // IPv6 multicast tests (ff00::/8 is the IPv6 multicast range)
+        let v6_mcast: IpNet = "ff02::1/128".parse().unwrap();
+        let v6_not_mcast: IpNet = "2001:db8::1/64".parse().unwrap();
+
+        assert!(v6_mcast.is_multicast());
+        assert!(!v6_not_mcast.is_multicast());
+
+        // Test for multicast_admin_scoped (site-local)
+        let v6_site_scoped_mcast: IpNet = "ff05::1/128".parse().unwrap();
+        // Test for multicast_admin_scoped (organization-local)
+        let v6_org_scoped_mcast: IpNet = "ff08::1/128".parse().unwrap();
+        // Test for a multicast address that is not admin scoped
+        let v6_not_admin_scoped_mcast: IpNet = "ff02::1/128".parse().unwrap();
+
+        assert!(v6_site_scoped_mcast.is_admin_scoped_multicast());
+        assert!(v6_org_scoped_mcast.is_admin_scoped_multicast());
+        assert!(!v6_not_admin_scoped_mcast.is_admin_scoped_multicast());
+        // Always false for IPv4
+        assert!(!v4_mcast.is_admin_scoped_multicast());
     }
 }

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -139,9 +139,10 @@ impl IpNet {
     }
 
     /// Return `true` iff this subnet is in a multicast address range with
-    /// administrative scope (site-local or organization-local) as defined in
-    /// [RFC 4291].
+    /// administrative scope (admin-local, site-local or organization-local) as
+    /// defined in [RFC 7346] and [RFC 4291].
     ///
+    /// [RFC 7346]: https://tools.ietf.org/html/rfc7346
     /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
     pub const fn is_admin_scoped_multicast(&self) -> bool {
         match self {
@@ -628,9 +629,10 @@ impl Ipv6Net {
     }
 
     /// Return `true` if this address is a multicast address with
-    /// administrative scope (site-local or organization-local) as defined in
-    /// [RFC 4291].
+    /// administrative scope (admin-local, site-local or organization-local) as
+    /// defined in [RFC 7346] and [RFC 4291].
     ///
+    /// [RFC 7346]: https://tools.ietf.org/html/rfc7346
     /// [RFC 4291]: https://tools.ietf.org/html/rfc4291
     pub const fn is_admin_scoped_multicast(&self) -> bool {
         if !self.addr.is_multicast() {
@@ -641,8 +643,9 @@ impl Ipv6Net {
         let segments = self.addr.segments();
         let scope = (segments[0] & 0x000F) as u8;
 
-        // RFC 4291: Scope values 5 (site-local) and 8 (organization-local)
-        matches!(scope, 0x5 | 0x8)
+        // RFC 4291/7346: Scope values 4 (admin-local), 5 (site-local) and
+        // 8 (organization-local)
+        matches!(scope, 0x4 | 0x5 | 0x8)
     }
 
     /// Return `true` iff this subnet is in a loopback address range.
@@ -1137,11 +1140,14 @@ mod tests {
         let v6_site_scoped_mcast: IpNet = "ff05::1/128".parse().unwrap();
         // Test for multicast_admin_scoped (organization-local)
         let v6_org_scoped_mcast: IpNet = "ff08::1/128".parse().unwrap();
+        //Test for multicast_admin_scoped (admin-local)
+        let v6_admin_scoped_mcast: IpNet = "ff04::1/128".parse().unwrap();
         // Test for a multicast address that is not admin scoped
         let v6_not_admin_scoped_mcast: IpNet = "ff02::1/128".parse().unwrap();
 
         assert!(v6_site_scoped_mcast.is_admin_scoped_multicast());
         assert!(v6_org_scoped_mcast.is_admin_scoped_multicast());
+        assert!(v6_admin_scoped_mcast.is_admin_scoped_multicast());
         assert!(!v6_not_admin_scoped_mcast.is_admin_scoped_multicast());
         // Always false for IPv4
         assert!(!v4_mcast.is_admin_scoped_multicast());


### PR DESCRIPTION
Includes:
    - Bumps Rust min-version to 1.84 for direct `is_unique_local` call on IPv6 addrs
    - Adds `is_admin_scoped_multicast` check for mcast IPv6 addrs that are site-local or org scoped
    - Set-up release for `v0.1.2`