### PR TITLE
update not on tag version (historically)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
 # Publishing a new release
 
 After merging a PR that updates the `oxnet` version number, you can cause a new
-release to be published on crates.io by pushing a tag of the form `v<semver>`.
+release to be published on crates.io by pushing a tag of the form `oxnet-<semver>`.


### PR DESCRIPTION
I'm just making an edit here to match tags as they have been here: https://github.com/oxidecomputer/oxnet/tags. 