### PR TITLE
IPv6 ULA builder, subnet resize function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +51,35 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -95,6 +133,16 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -189,10 +237,21 @@ dependencies = [
  "expectorate",
  "ipnetwork",
  "macaddr",
+ "rand",
  "regress",
  "schemars",
  "serde",
  "serde_json",
+ "sha1",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -218,6 +277,35 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "regress"
@@ -340,6 +428,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "similar"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +491,12 @@ name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -476,4 +587,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "1.0.228", optional = true }
 serde_json = { version = "1.0.145", optional = true }
 ipnetwork = { version = "0.21.1", optional = true }
 macaddr = { version = "1.0.1", optional = true }
+sha1 = "0.10.6"
+rand = "0.9.2"
 
 [dev-dependencies]
 expectorate = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ipnetwork = ["dep:ipnetwork"]
 macaddr = ["dep:macaddr"]
 schemars = ["dep:schemars", "dep:serde_json"]
 serde = ["dep:serde"]
+ula = ["dep:sha1", "dep:rand"]
 std = []
 
 [dependencies]
@@ -25,8 +26,8 @@ serde = { version = "1.0.228", optional = true }
 serde_json = { version = "1.0.145", optional = true }
 ipnetwork = { version = "0.21.1", optional = true }
 macaddr = { version = "1.0.1", optional = true }
-sha1 = "0.10.6"
-rand = "0.9.2"
+sha1 = { version = "0.10.6", optional = true }
+rand = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 expectorate = "1.2.0"

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1396,8 +1396,7 @@ mod tests {
                 let net = format!("{case}/{prefix}");
                 assert!(
                     re.find(&net).is_some(),
-                    "Expected to match IPv6 case: {}",
-                    prefix,
+                    "Expected to match IPv6 case: {prefix}",
                 );
             }
         }
@@ -1415,7 +1414,7 @@ mod tests {
         let net: IpNet = net_str.parse().unwrap();
         let ser = serde_json::to_string(&net).unwrap();
 
-        assert_eq!(format!(r#""{}""#, net_str), ser);
+        assert_eq!(format!(r#""{net_str}""#), ser);
         let net_des = serde_json::from_str::<IpNet>(&ser).unwrap();
         assert_eq!(net, net_des);
 
@@ -1423,7 +1422,7 @@ mod tests {
         let net: IpNet = net_str.parse().unwrap();
         let ser = serde_json::to_string(&net).unwrap();
 
-        assert_eq!(format!(r#""{}""#, net_str), ser);
+        assert_eq!(format!(r#""{net_str}""#), ser);
         let net_des = serde_json::from_str::<IpNet>(&ser).unwrap();
         assert_eq!(net, net_des);
 
@@ -1431,7 +1430,7 @@ mod tests {
         let net: IpNet = net_str.parse().unwrap();
         let ser = serde_json::to_string(&net).unwrap();
 
-        assert_eq!(format!(r#""{}""#, net_str), ser);
+        assert_eq!(format!(r#""{net_str}""#), ser);
         let net_des = serde_json::from_str::<IpNet>(&ser).unwrap();
         assert_eq!(net, net_des);
 
@@ -1439,7 +1438,7 @@ mod tests {
         let net: IpNet = net_str.parse().unwrap();
         let ser = serde_json::to_string(&net).unwrap();
 
-        assert_eq!(format!(r#""{}""#, net_str), ser);
+        assert_eq!(format!(r#""{net_str}""#), ser);
         let net_des = serde_json::from_str::<IpNet>(&ser).unwrap();
         assert_eq!(net, net_des);
     }

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -3,10 +3,13 @@
 use std::{
     net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr},
     num::ParseIntError,
-    time::{SystemTime, SystemTimeError},
 };
 
-use rand::Rng;
+#[cfg(feature = "ula")]
+use {
+    rand::Rng,
+    std::time::{SystemTime, SystemTimeError},
+};
 
 /// A prefix error during the creation of an [IpNet], [Ipv4Net], or [Ipv6Net]
 #[derive(Debug, Clone, PartialEq)]
@@ -606,7 +609,7 @@ impl Ipv4Net {
     ///
     /// Basic usage:
     /// ```
-    /// use oxnet::Ipv4Net;
+    /// # use oxnet::Ipv4Net;
     /// let s16: Ipv4Net = "10.1.0.0/16".parse().unwrap();
     /// // Extend to /24 by adding 0x02 in the third octet
     /// let s24 = s16.resize(24, 2).unwrap();
@@ -615,7 +618,7 @@ impl Ipv4Net {
     ///
     /// Non-zero values in host-bits:
     /// ```
-    /// use oxnet::Ipv4Net;
+    /// # use oxnet::Ipv4Net;
     /// let s16: Ipv4Net = "10.1.2.3/16".parse().unwrap();
     /// let s24 = s16.resize(24, 0).unwrap();
     /// assert_eq!(s24, "10.1.2.3/24".parse().unwrap());
@@ -1010,7 +1013,7 @@ impl Ipv6Net {
     /// # Examples
     /// Basic usage:
     /// ```
-    /// use oxnet::Ipv6Net;
+    /// # use oxnet::Ipv6Net;
     /// let s56: Ipv6Net = "fd00:a:b:cc00::/56".parse().unwrap();
     /// // Extend a /56 to a /64
     /// let s64 = s56.resize(64, 0xdd).unwrap();
@@ -1019,7 +1022,7 @@ impl Ipv6Net {
     ///
     /// Non-zero values in host-bits:
     /// ```
-    /// use oxnet::Ipv6Net;
+    /// # use oxnet::Ipv6Net;
     /// let s56: Ipv6Net = "fd00:a:b:ccdd::/56".parse().unwrap();
     /// let s64 = s56.resize(64, 0).unwrap();
     /// assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
@@ -1189,15 +1192,17 @@ impl Iterator for Ipv6NetIter {
     }
 }
 
-/// Error conditions that can arise when building a ULA.
+/// Error conditions that can arise from [UlaBuilder::build]
+#[cfg(feature = "ula")]
 #[derive(Debug, Clone)]
 pub enum UlaBuildError {
-    /// An error occured using a user specified time to build a ULA.
+    /// An error occurred using a user specified time to build a ULA
     Time(SystemTimeError),
-    /// An error occured constructing the built prefix.
+    /// An error occurred constructing the built prefix
     Prefix(IpNetPrefixError),
 }
 
+#[cfg(feature = "ula")]
 impl std::fmt::Display for UlaBuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1207,14 +1212,17 @@ impl std::fmt::Display for UlaBuildError {
     }
 }
 
+#[cfg(feature = "ula")]
 impl std::error::Error for UlaBuildError {}
 
+#[cfg(feature = "ula")]
 impl From<SystemTimeError> for UlaBuildError {
     fn from(value: SystemTimeError) -> Self {
         Self::Time(value)
     }
 }
 
+#[cfg(feature = "ula")]
 impl From<IpNetPrefixError> for UlaBuildError {
     fn from(value: IpNetPrefixError) -> Self {
         Self::Prefix(value)
@@ -1222,12 +1230,14 @@ impl From<IpNetPrefixError> for UlaBuildError {
 }
 
 /// Build an IPv6 unique local address that conforms to RFC 4193.
+#[cfg(feature = "ula")]
 #[derive(Default)]
 pub struct UlaBuilder {
     date: Option<SystemTime>,
     id: Option<Vec<u8>>,
 }
 
+#[cfg(feature = "ula")]
 impl UlaBuilder {
     /// Set the ULA id.
     pub fn id(&mut self, id: impl AsRef<[u8]>) -> &mut Self {
@@ -1287,6 +1297,7 @@ impl UlaBuilder {
     }
 }
 
+#[cfg(feature = "ula")]
 fn system_time_to_ntp(time: SystemTime) -> Result<u64, SystemTimeError> {
     use std::time::UNIX_EPOCH;
 
@@ -1657,6 +1668,7 @@ mod tests {
         assert!(!Global.is_admin_scoped_multicast());
     }
 
+    #[cfg(feature = "ula")]
     #[test]
     fn test_ipv6_ula_builder() {
         // ULAs built without any parameters should result in a random /48 in

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -3,10 +3,13 @@
 use std::{
     net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr},
     num::ParseIntError,
+    time::{SystemTime, SystemTimeError},
 };
 
+use rand::Rng;
+
 /// A prefix error during the creation of an [IpNet], [Ipv4Net], or [Ipv6Net]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct IpNetPrefixError(u8);
 
 impl std::fmt::Display for IpNetPrefixError {
@@ -391,8 +394,12 @@ impl Ipv4Net {
     }
 
     pub(crate) fn mask(&self) -> u32 {
+        Self::mask_for_width(self.width)
+    }
+
+    pub(crate) fn mask_for_width(width: u8) -> u32 {
         u32::MAX
-            .checked_shl((IPV4_NET_WIDTH_MAX - self.width) as u32)
+            .checked_shl((IPV4_NET_WIDTH_MAX - width) as u32)
             .unwrap_or(0)
     }
 
@@ -581,6 +588,59 @@ impl Ipv4Net {
 
         child.is_subnet_of(parent)
     }
+
+    /// Resize this subnet.
+    ///
+    /// If the new width is less than the current width the underlying address
+    /// is truncated to the new width.
+    ///
+    /// If the new width is greater than the current width the underlying
+    /// address is extended with the `fill` bits. The `fill` value is shifted
+    /// so first byte of the fill is used for the first byte of the extended
+    /// subnet. After shifting, the fill is truncated to not extend beyond the
+    /// new width. The `fill` is applied as a logical or. If the source prefix
+    /// has non-zero values in host bits and `fill` is non-zero, the result
+    /// will be the logical or of the `fill` with the host bits.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use oxnet::Ipv4Net;
+    /// let s16: Ipv4Net = "10.1.0.0/16".parse().unwrap();
+    /// // Extend to /24 by adding 0x02 in the third octet
+    /// let s24 = s16.resize(24, 2).unwrap();
+    /// assert_eq!(s24.to_string(), "10.1.2.0/24");
+    /// ```
+    ///
+    /// Non-zero values in host-bits:
+    /// ```
+    /// use oxnet::Ipv4Net;
+    /// let s16: Ipv4Net = "10.1.2.3/16".parse().unwrap();
+    /// let s24 = s16.resize(24, 0).unwrap();
+    /// assert_eq!(s24, "10.1.2.3/24".parse().unwrap());
+    /// let s24 = s16.resize(24, 255).unwrap();
+    /// assert_eq!(s24, "10.1.255.3/24".parse().unwrap());
+    /// ```
+    pub fn resize(&self, width: u8, fill: u32) -> Result<Self, IpNetPrefixError> {
+        if width > IPV4_NET_WIDTH_MAX {
+            return Err(IpNetPrefixError(width));
+        }
+        if width < self.width {
+            Ok(Self {
+                addr: Ipv4Addr::from(u32::from(self.addr) & Self::mask_for_width(width)),
+                width,
+            })
+        } else if width == self.width {
+            Ok(*self)
+        } else {
+            let fill = (fill << (IPV4_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
+            Ok(Self {
+                addr: Ipv4Addr::from(u32::from(self.addr) | fill),
+                width,
+            })
+        }
+    }
 }
 
 impl std::fmt::Display for Ipv4Net {
@@ -751,8 +811,12 @@ impl Ipv6Net {
     }
 
     pub(crate) fn mask(&self) -> u128 {
+        Self::mask_for_width(self.width)
+    }
+
+    pub(crate) fn mask_for_width(width: u8) -> u128 {
         u128::MAX
-            .checked_shl((IPV6_NET_WIDTH_MAX - self.width) as u32)
+            .checked_shl((IPV6_NET_WIDTH_MAX - width) as u32)
             .unwrap_or(0)
     }
 
@@ -929,6 +993,58 @@ impl Ipv6Net {
 
         child.is_subnet_of(parent)
     }
+
+    /// Resize this subnet.
+    ///
+    /// If the new width is less than the current width the underlying address
+    /// is truncated to the new width.
+    ///
+    /// If the new width is greater than the current width the underlying
+    /// address is extended with the `fill` bits. The `fill` value is shifted
+    /// so first byte of the fill is used for the first byte of the extended
+    /// subnet. After shifting, the fill is truncated to not extend beyond the
+    /// new width. The `fill` is applied as a logical or. If the source prefix
+    /// has non-zero values in host bits and `fill` is non-zero, the result
+    /// will be the logical or of the `fill` with the host bits.
+    ///
+    /// # Examples
+    /// Basic usage:
+    /// ```
+    /// use oxnet::Ipv6Net;
+    /// let s56: Ipv6Net = "fd00:a:b:cc00::/56".parse().unwrap();
+    /// // Extend a /56 to a /64
+    /// let s64 = s56.resize(64, 0xdd).unwrap();
+    /// assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
+    /// ```
+    ///
+    /// Non-zero values in host-bits:
+    /// ```
+    /// use oxnet::Ipv6Net;
+    /// let s56: Ipv6Net = "fd00:a:b:ccdd::/56".parse().unwrap();
+    /// let s64 = s56.resize(64, 0).unwrap();
+    /// assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
+    /// let s64 = s56.resize(64, 0xff).unwrap();
+    /// assert_eq!(s64, "fd00:a:b:ccff::/64".parse().unwrap());
+    /// ```
+    pub fn resize(&self, width: u8, fill: u128) -> Result<Self, IpNetPrefixError> {
+        if width > IPV6_NET_WIDTH_MAX {
+            return Err(IpNetPrefixError(width));
+        }
+        if width < self.width {
+            Ok(Self {
+                addr: Ipv6Addr::from(u128::from(self.addr) & Self::mask_for_width(width)),
+                width,
+            })
+        } else if width == self.width {
+            Ok(*self)
+        } else {
+            let fill = (fill << (IPV6_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
+            Ok(Self {
+                addr: Ipv6Addr::from(u128::from(self.addr) | fill),
+                width,
+            })
+        }
+    }
 }
 
 impl std::fmt::Display for Ipv6Net {
@@ -1071,6 +1187,119 @@ impl Iterator for Ipv6NetIter {
         self.next = (nth <= self.last).then_some(nth);
         self.next()
     }
+}
+
+/// Error conditions that can arise when building a ULA.
+#[derive(Debug, Clone)]
+pub enum UlaBuildError {
+    /// An error occured using a user specified time to build a ULA.
+    Time(SystemTimeError),
+    /// An error occured constructing the built prefix.
+    Prefix(IpNetPrefixError),
+}
+
+impl std::fmt::Display for UlaBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Time(e) => write!(f, "invalid time provided: {e}"),
+            Self::Prefix(e) => write!(f, "unable to construct ULA prefix: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for UlaBuildError {}
+
+impl From<SystemTimeError> for UlaBuildError {
+    fn from(value: SystemTimeError) -> Self {
+        Self::Time(value)
+    }
+}
+
+impl From<IpNetPrefixError> for UlaBuildError {
+    fn from(value: IpNetPrefixError) -> Self {
+        Self::Prefix(value)
+    }
+}
+
+/// Build an IPv6 unique local address that conforms to RFC 4193.
+#[derive(Default)]
+pub struct UlaBuilder {
+    date: Option<SystemTime>,
+    id: Option<Vec<u8>>,
+}
+
+impl UlaBuilder {
+    /// Set the ULA id.
+    pub fn id(&mut self, id: impl AsRef<[u8]>) -> &mut Self {
+        self.id = Some(id.as_ref().to_vec());
+        self
+    }
+
+    /// Set the ULA generation date.
+    pub fn date(&mut self, date: SystemTime) -> &mut Self {
+        self.date = Some(date);
+        self
+    }
+
+    /// Produce the Ipv6Net from the builder.
+    ///
+    /// This will produce a /48 with `fd` as the leading 8 bits followed by 40
+    /// random bits that are determined according to the algorithm in RFC 4193
+    /// section 3.2.2. Subsequent modification such as resizing to a /56 or /64
+    /// can be accomplished with `[Ipv6Net::resize]`.
+    pub fn build(&self) -> Result<Ipv6Net, UlaBuildError> {
+        use sha1::{Digest, Sha1};
+        use std::time::SystemTime;
+
+        // Get or generate ID (8 bytes)
+        let id: Vec<u8> = self.id.clone().unwrap_or_else(|| {
+            let mut rng = rand::rng();
+            rng.random::<[u8; 8]>().to_vec()
+        });
+
+        // Get time and convert to NTP format
+        let time = self.date.unwrap_or_else(SystemTime::now);
+        let ntp_time = system_time_to_ntp(time)?;
+
+        // Hash the inputs per RFC 4193
+        let mut hasher = Sha1::new();
+        hasher.update(ntp_time.to_be_bytes());
+        hasher.update(&id);
+        let hash = hasher.finalize();
+
+        // Extract 40 bits (5 bytes) for Global ID
+        let global_id = &hash[..5];
+
+        // Build the fd00::/48 prefix
+        // Format: fd + 40-bit Global ID + 16-bit Subnet ID (0 for /48)
+        let addr = Ipv6Addr::new(
+            0xfd00 | (global_id[0] as u16),
+            u16::from_be_bytes([global_id[1], global_id[2]]),
+            u16::from_be_bytes([global_id[3], global_id[4]]),
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+
+        Ok(Ipv6Net::new(addr, 48)?)
+    }
+}
+
+fn system_time_to_ntp(time: SystemTime) -> Result<u64, SystemTimeError> {
+    use std::time::UNIX_EPOCH;
+
+    // NTP epoch is 1900-01-01 00:00:00 UTC
+    // Unix epoch is 1970-01-01 00:00:00 UTC
+    // Difference is 70 years = 2208988800 seconds
+    const NTP_UNIX_OFFSET: u64 = 2208988800;
+
+    let duration = time.duration_since(UNIX_EPOCH)?;
+    let secs = duration.as_secs() + NTP_UNIX_OFFSET;
+    let frac = ((duration.subsec_nanos() as u64) << 32) / 1_000_000_000;
+
+    Ok((secs << 32) | frac)
 }
 
 #[cfg(feature = "ipnetwork")]
@@ -1426,5 +1655,83 @@ mod tests {
         assert!(SiteLocal.is_admin_scoped_multicast());
         assert!(OrganizationLocal.is_admin_scoped_multicast());
         assert!(!Global.is_admin_scoped_multicast());
+    }
+
+    #[test]
+    fn test_ipv6_ula_builder() {
+        // ULAs built without any parameters should result in a random /48 in
+        // fd::/8.
+        let ula1 = UlaBuilder::default().build().unwrap();
+        let ula2 = UlaBuilder::default().build().unwrap();
+        assert_eq!(ula1.width(), 48);
+        assert_ne!(ula1, ula2);
+
+        // If the id is not specified, it will be random, so these
+        // should still not match.
+        let t = SystemTime::now();
+        let ula1 = UlaBuilder::default().date(t).build().unwrap();
+        let ula2 = UlaBuilder::default().date(t).build().unwrap();
+        assert_ne!(ula1, ula2);
+
+        // Builders where the date and ID are specified should be
+        // deterministic.
+        let ula1 = UlaBuilder::default()
+            .date(t)
+            .id(vec![1, 2, 3, 4])
+            .build()
+            .unwrap();
+        let ula2 = UlaBuilder::default()
+            .date(t)
+            .id(vec![1, 2, 3, 4])
+            .build()
+            .unwrap();
+        assert_eq!(ula1, ula2);
+    }
+
+    #[test]
+    fn test_ipv6_resize() {
+        let s56: Ipv6Net = "fd00:a:b:cc00::/56".parse().unwrap();
+
+        // Extend a /56 to a /64
+        let s64 = s56.resize(64, 0xdd).unwrap();
+        assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
+
+        // Truncate a /56 to a /48
+        let s48 = s56.resize(48, 0).unwrap();
+        assert_eq!(s48, "fd00:a:b::/48".parse().unwrap());
+
+        // Extending to a /200 should be an error
+        assert_eq!(s56.resize(200, 0), Result::Err(IpNetPrefixError(200)));
+
+        // Operating on non-cannonical form
+        let s56: Ipv6Net = "fd00:a:b:ccdd::/56".parse().unwrap();
+        let s64 = s56.resize(64, 0).unwrap();
+        assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
+        let s64 = s56.resize(64, 0xff).unwrap();
+        assert_eq!(s64, "fd00:a:b:ccff::/64".parse().unwrap());
+    }
+
+    #[test]
+    fn test_ipv4_resize() {
+        let s16: Ipv4Net = "10.1.0.0/16".parse().unwrap();
+
+        // Extend a /16 to a /24
+        let s24 = s16.resize(24, 2).unwrap();
+        assert_eq!(s24, "10.1.2.0/24".parse().unwrap());
+
+        // Truncate a /16 to a /8
+        let s8 = s24.resize(8, 0).unwrap();
+        assert_eq!(s8, "10.0.0.0/8".parse().unwrap());
+
+        // Extending to a /40 should be an error
+        assert_eq!(s16.resize(40, 0), Result::Err(IpNetPrefixError(40)));
+
+        // Operating on non-cannonical form
+        let s16: Ipv4Net = "10.1.2.3/16".parse().unwrap();
+        // Extend a /16 to a /24
+        let s24 = s16.resize(24, 0).unwrap();
+        assert_eq!(s24, "10.1.2.3/24".parse().unwrap());
+        let s24 = s16.resize(24, 255).unwrap();
+        assert_eq!(s24, "10.1.255.3/24".parse().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod multicast;
 mod schema_util;
 
 pub use ipnet::{
-    IpNet, IpNetParseError, IpNetPrefixError, Ipv4Net, Ipv6Net, IPV4_NET_WIDTH_MAX,
-    IPV6_NET_WIDTH_MAX,
+    IpNet, IpNetParseError, IpNetPrefixError, Ipv4Net, Ipv6Net, UlaBuildError, UlaBuilder,
+    IPV4_NET_WIDTH_MAX, IPV6_NET_WIDTH_MAX,
 };
 pub use multicast::MulticastMac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,11 @@ mod multicast;
 mod schema_util;
 
 pub use ipnet::{
-    IpNet, IpNetParseError, IpNetPrefixError, Ipv4Net, Ipv6Net, UlaBuildError, UlaBuilder,
-    IPV4_NET_WIDTH_MAX, IPV6_NET_WIDTH_MAX,
+    IpNet, IpNetParseError, IpNetPrefixError, Ipv4Net, Ipv6Net, IPV4_NET_WIDTH_MAX,
+    IPV6_NET_WIDTH_MAX,
 };
+
+#[cfg(feature = "ula")]
+pub use ipnet::{UlaBuildError, UlaBuilder};
+
 pub use multicast::MulticastMac;


### PR DESCRIPTION
- Adds an IPv6 ULA (Unique Local Address) builder that conforms to RFC 4193 [guidance](https://datatracker.ietf.org/doc/html/rfc4193#section-3.2.2) for ULA construction.
- Adds a resize function to `Ipv4Net` and `Ipv6Net` that yields a new subnet by either extending or truncating the subnet width.