### PR TITLE
Add wrapper types for SocketAddr{,V4,V6} with the x-rust-type extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+## [0.1.6] - 2026-06-01
+
+* Adds `SocketAddr`{,`V4`,`V6`} wrappers with the `x-rust-type` extension
+
 ## [0.1.5] - 2026-05-01
 
 * Adds an IPv6 ULA (Unique Local Address) builder pre RFC 4193
@@ -41,6 +45,7 @@
 
 Initial release.
 
+[0.1.6]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.6
 [0.1.5]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.5
 [0.1.4]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.4
 [0.1.3]: https://github.com/oxidecomputer/oxnet/releases/oxnet-0.1.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -232,7 +232,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxnet"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "expectorate",
  "ipnetwork",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.10.4"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
  "hashbrown",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "foldhash"
-version = "0.2.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.10.5"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
 dependencies = [
  "hashbrown",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.11.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
 dependencies = [
  "hashbrown",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxnet"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -31,4 +31,4 @@ rand = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 expectorate = "1.2.0"
-regress = "0.10.4"
+regress = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ rand = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 expectorate = "1.2.0"
-regress = "0.11.1"
+regress = "0.10.4"

--- a/all_schemas.json
+++ b/all_schemas.json
@@ -1,7 +1,39 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Null",
-  "type": "null",
+  "title": "Root",
+  "description": "Object to validate types with inlined schemas.",
+  "type": "object",
+  "required": [
+    "addr",
+    "addr_v4",
+    "addr_v6"
+  ],
+  "properties": {
+    "addr": {
+      "type": "string",
+      "x-rust-type": {
+        "crate": "std",
+        "path": "std::net::SocketAddr",
+        "version": ">=1.0.0"
+      }
+    },
+    "addr_v4": {
+      "type": "string",
+      "x-rust-type": {
+        "crate": "std",
+        "path": "std::net::SocketAddrV4",
+        "version": ">=1.0.0"
+      }
+    },
+    "addr_v6": {
+      "type": "string",
+      "x-rust-type": {
+        "crate": "std",
+        "path": "std::net::SocketAddrV6",
+        "version": ">=1.0.0"
+      }
+    }
+  },
   "definitions": {
     "IpNet": {
       "oneOf": [

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1371,6 +1371,7 @@ mod ipnetwork_feature {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "schemars")]
     #[test]
     fn test_ipv6_regex() {
         let re = regress::Regex::new(IPV6_NET_REGEX).unwrap();
@@ -1408,6 +1409,7 @@ mod tests {
         assert_eq!(x, IpNet::V4("0.0.0.0/0".parse().unwrap()));
     }
 
+    #[cfg(feature = "schemars")]
     #[test]
     fn test_ipnet_serde() {
         let net_str = "fd00:2::/32";
@@ -1714,7 +1716,7 @@ mod tests {
         // Extending to a /200 should be an error
         assert_eq!(s56.resize(200, 0), Result::Err(IpNetPrefixError(200)));
 
-        // Operating on non-cannonical form
+        // Operating on non-canonical form
         let s56: Ipv6Net = "fd00:a:b:ccdd::/56".parse().unwrap();
         let s64 = s56.resize(64, 0).unwrap();
         assert_eq!(s64, "fd00:a:b:ccdd::/64".parse().unwrap());
@@ -1737,7 +1739,7 @@ mod tests {
         // Extending to a /40 should be an error
         assert_eq!(s16.resize(40, 0), Result::Err(IpNetPrefixError(40)));
 
-        // Operating on non-cannonical form
+        // Operating on non-canonical form
         let s16: Ipv4Net = "10.1.2.3/16".parse().unwrap();
         // Extend a /16 to a /24
         let s24 = s16.resize(24, 0).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -8,6 +8,7 @@ mod ipnet;
 mod multicast;
 #[cfg(feature = "schemars")]
 mod schema_util;
+mod sockaddr;
 
 pub use ipnet::{
     IpNet, IpNetParseError, IpNetPrefixError, Ipv4Net, Ipv6Net, IPV4_NET_WIDTH_MAX,
@@ -18,3 +19,5 @@ pub use ipnet::{
 pub use ipnet::{UlaBuildError, UlaBuilder};
 
 pub use multicast::MulticastMac;
+
+pub use sockaddr::{SocketAddrJson, SocketAddrV4Json, SocketAddrV6Json};

--- a/src/schema_util.rs
+++ b/src/schema_util.rs
@@ -78,7 +78,16 @@ mod tests {
         let _ = gen.subschema_for::<Ipv4Net>();
         let _ = gen.subschema_for::<Ipv6Net>();
 
-        let root = gen.into_root_schema_for::<()>();
+        /// Object to validate types with inlined schemas.
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct Root {
+            addr: SocketAddrJson,
+            addr_v4: SocketAddrV4Json,
+            addr_v6: SocketAddrV6Json,
+        }
+
+        let root = gen.into_root_schema_for::<Root>();
 
         expectorate::assert_contents(
             "all_schemas.json",

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -1,0 +1,116 @@
+// Copyright 2026 Oxide Computer Company
+
+use std::{
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    ops::{Deref, DerefMut},
+};
+
+macro_rules! socket_addr_json_wrapper {
+    ($wrapper:ident, $inner:ty) => {
+        /// A wrapper around `
+        #[doc = stringify!($inner)]
+        /// ` that implements schemars::JsonSchema to indicate the appropriate
+        /// Rust type to use for generated clients.
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(transparent))]
+        pub struct $wrapper(pub $inner);
+
+        impl Deref for $wrapper {
+            type Target = $inner;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $wrapper {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+
+        impl From<$inner> for $wrapper {
+            fn from(addr: $inner) -> Self {
+                Self(addr)
+            }
+        }
+
+        #[cfg(feature = "schemars")]
+        impl schemars::JsonSchema for $wrapper {
+            fn schema_name() -> String {
+                stringify!($inner).to_string()
+            }
+
+            fn json_schema(
+                gen: &mut schemars::gen::SchemaGenerator,
+            ) -> schemars::schema::Schema {
+                let schema = gen.subschema_for::<$inner>();
+                let mut schema_object = schema.into_object();
+                schema_object.extensions.insert(
+                    "x-rust-type".to_string(),
+                    serde_json::json!({
+                        "crate": "std",
+                        "version": ">=1.0.0",
+                        "path": concat!("std::net::", stringify!($inner)),
+                    }),
+                );
+                schema_object.into()
+            }
+
+            fn is_referenceable() -> bool {
+                // We want this to be inlined like the inner type.
+                false
+            }
+        }
+    };
+}
+
+socket_addr_json_wrapper!(SocketAddrJson, SocketAddr);
+socket_addr_json_wrapper!(SocketAddrV4Json, SocketAddrV4);
+socket_addr_json_wrapper!(SocketAddrV6Json, SocketAddrV6);
+
+impl From<SocketAddrV4> for SocketAddrJson {
+    fn from(addr: SocketAddrV4) -> Self {
+        Self(SocketAddr::from(addr))
+    }
+}
+
+impl From<SocketAddrV6> for SocketAddrJson {
+    fn from(addr: SocketAddrV6) -> Self {
+        Self(SocketAddr::from(addr))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "schemars")]
+    #[test]
+    fn test_sockaddr_serialization() {
+        use super::*;
+
+        let base: SocketAddrV4 = "0.0.0.0:0".parse().unwrap();
+        let wrap = SocketAddrV4Json::from(base.clone());
+
+        assert_eq!(
+            serde_json::to_string(&wrap).unwrap(),
+            serde_json::to_string(&base).unwrap(),
+        );
+
+        let base: SocketAddrV6 = "[::]:0".parse().unwrap();
+        let wrap = SocketAddrV6Json::from(base.clone());
+
+        assert_eq!(
+            serde_json::to_string(&wrap).unwrap(),
+            serde_json::to_string(&base).unwrap(),
+        );
+
+        let base: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        let wrap = SocketAddrJson::from(base.clone());
+
+        assert_eq!(
+            serde_json::to_string(&wrap).unwrap(),
+            serde_json::to_string(&base).unwrap(),
+        );
+    }
+}


### PR DESCRIPTION
Also:
- some typos
- fixed issues with `cargo test --no-default-features`

Closes #81 