### PR TITLE
Cleanup test trait bounds and clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ default = ["serde", "schemars", "ipnetwork"]
 ipnetwork = ["dep:ipnetwork"]
 macaddr = ["dep:macaddr"]
 schemars = ["dep:schemars", "dep:serde_json"]
-serde = ["dep:serde", "serde/derive"]
+serde = ["dep:serde"]
 ula = ["dep:sha1", "dep:rand"]
 std = []
 
 [dependencies]
 schemars = {version = "0.8.22", optional = true }
-serde = { version = "1.0.228", optional = true }
+serde = { version = "1.0.228", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.145", optional = true }
 ipnetwork = { version = "0.21.1", optional = true }
 macaddr = { version = "1.0.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["serde", "schemars", "ipnetwork"]
 ipnetwork = ["dep:ipnetwork"]
 macaddr = ["dep:macaddr"]
 schemars = ["dep:schemars", "dep:serde_json"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "serde/derive"]
 ula = ["dep:sha1", "dep:rand"]
 std = []
 

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1,6 +1,7 @@
 // Copyright 2025 Oxide Computer Company
 
 use std::{
+    cmp::Ordering,
     net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr},
     num::ParseIntError,
 };
@@ -629,19 +630,19 @@ impl Ipv4Net {
         if width > IPV4_NET_WIDTH_MAX {
             return Err(IpNetPrefixError(width));
         }
-        if width < self.width {
-            Ok(Self {
+        match width.cmp(&self.width) {
+            Ordering::Less => Ok(Self {
                 addr: Ipv4Addr::from(u32::from(self.addr) & Self::mask_for_width(width)),
                 width,
-            })
-        } else if width == self.width {
-            Ok(*self)
-        } else {
-            let fill = (fill << (IPV4_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
-            Ok(Self {
-                addr: Ipv4Addr::from(u32::from(self.addr) | fill),
-                width,
-            })
+            }),
+            Ordering::Equal => Ok(*self),
+            Ordering::Greater => {
+                let fill = (fill << (IPV4_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
+                Ok(Self {
+                    addr: Ipv4Addr::from(u32::from(self.addr) | fill),
+                    width,
+                })
+            }
         }
     }
 }
@@ -1033,19 +1034,19 @@ impl Ipv6Net {
         if width > IPV6_NET_WIDTH_MAX {
             return Err(IpNetPrefixError(width));
         }
-        if width < self.width {
-            Ok(Self {
+        match width.cmp(&self.width) {
+            Ordering::Less => Ok(Self {
                 addr: Ipv6Addr::from(u128::from(self.addr) & Self::mask_for_width(width)),
                 width,
-            })
-        } else if width == self.width {
-            Ok(*self)
-        } else {
-            let fill = (fill << (IPV6_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
-            Ok(Self {
-                addr: Ipv6Addr::from(u128::from(self.addr) | fill),
-                width,
-            })
+            }),
+            Ordering::Equal => Ok(*self),
+            Ordering::Greater => {
+                let fill = (fill << (IPV6_NET_WIDTH_MAX - width)) & Self::mask_for_width(width);
+                Ok(Self {
+                    addr: Ipv6Addr::from(u128::from(self.addr) | fill),
+                    width,
+                })
+            }
         }
     }
 }

--- a/src/ipnet.rs
+++ b/src/ipnet.rs
@@ -1409,7 +1409,7 @@ mod tests {
         assert_eq!(x, IpNet::V4("0.0.0.0/0".parse().unwrap()));
     }
 
-    #[cfg(feature = "schemars")]
+    #[cfg(all(feature = "schemars", feature = "serde"))]
     #[test]
     fn test_ipnet_serde() {
         let net_str = "fd00:2::/32";

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -90,7 +90,7 @@ mod tests {
         use super::*;
 
         let base: SocketAddrV4 = "0.0.0.0:0".parse().unwrap();
-        let wrap = SocketAddrV4Json::from(base.clone());
+        let wrap = SocketAddrV4Json::from(base);
 
         assert_eq!(
             serde_json::to_string(&wrap).unwrap(),
@@ -98,7 +98,7 @@ mod tests {
         );
 
         let base: SocketAddrV6 = "[::]:0".parse().unwrap();
-        let wrap = SocketAddrV6Json::from(base.clone());
+        let wrap = SocketAddrV6Json::from(base);
 
         assert_eq!(
             serde_json::to_string(&wrap).unwrap(),
@@ -106,7 +106,7 @@ mod tests {
         );
 
         let base: SocketAddr = "0.0.0.0:0".parse().unwrap();
-        let wrap = SocketAddrJson::from(base.clone());
+        let wrap = SocketAddrJson::from(base);
 
         assert_eq!(
             serde_json::to_string(&wrap).unwrap(),

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -84,7 +84,7 @@ impl From<SocketAddrV6> for SocketAddrJson {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "schemars")]
+    #[cfg(all(feature = "schemars", feature = "serde"))]
     #[test]
     fn test_sockaddr_serialization() {
         use super::*;


### PR DESCRIPTION
`cargo test --no-default-features --features serde` failed because the crate serde feature did not enable serde’s derive macros:

    error[E0433]: cannot find `Deserialize` in `serde`
    error[E0433]: cannot find `Serialize` in `serde`

`cargo test --no-default-features --features schemars` failed because serialization tests gated only on schemars were compiled without the crate serde feature:

    error[E0277]: the trait bound `IpNet: serde::Serialize` is not satisfied
    error[E0277]: the trait bound `SocketAddrJson: serde::Serialize` is not satisfied

Enable serde derive support when the serde feature is selected, and only compile serialization tests when both serde and serde_json are available.

`cargo +1.85.0 clippy --all-targets --all-features --locked -- -D warnings`
failed for the IPv4 and IPv6 resize implementations with:

    error: `if` chain can be rewritten with `match`
      --> src/ipnet.rs:632:9

    error: `if` chain can be rewritten with `match`
      --> src/ipnet.rs:1036:9

Rewrite both condition chains as matches on Ordering without changing their
behavior.

`cargo clippy --all-targets --all-features --locked -- -D warnings` failed
in the socket address serialization test with:

    error: using `clone` on type `SocketAddrV4` which implements the `Copy` trait
      --> src/sockaddr.rs:93:43

    error: using `clone` on type `SocketAddrV6` which implements the `Copy` trait
      --> src/sockaddr.rs:101:43

    error: using `clone` on type `SocketAddr` which implements the `Copy` trait
      --> src/sockaddr.rs:109:41

Remove the redundant clones.